### PR TITLE
change user.id to user.discord_id for the swaggest

### DIFF
--- a/swag/bank.py
+++ b/swag/bank.py
@@ -195,7 +195,7 @@ class SwagBank:
 
     def get_the_new_swaggest(self):
         for user in self.get_forbes():
-            return user.id
+            return user.discord_id
 
     def update_bonus_growth_rate(self):
         forbes = sorted(


### PR DESCRIPTION
The function get_the_new_swaggest should return the discord_id instead of the id, because the returned id is immediatly used by a guild.get_member() function which need a discord_id.