### PR TITLE
Issues 23 : log_channel

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,8 @@ from swag.client.yfu import YfuCommand
 
 from disnake.ext import commands
 
+from utils import LOG_CHANNEL_ID
+
 with open("config.json", "r") as json_file:
     client_config = json.load(json_file)
 
@@ -62,9 +64,11 @@ async def on_ready():
 
     print("Bybbot opérationnel !")
 
-    await client.get_channel(930777218496479302).send(
-        "Démarrage terminé, prêt à bybbotter des clous !"
-    )
+    #Si un channel est spécifié dans le fichier de conf
+    if LOG_CHANNEL_ID:
+        await client.get_channel(LOG_CHANNEL_ID).send(
+            "Démarrage terminé, prêt à bybbotter des clous !"
+        )
 
 
 @client.event
@@ -122,26 +126,31 @@ async def on_message(message):
         return
 
     for module in modules:
-        try:
+
+        if LOG_CHANNEL_ID:
+            try:
+                await module.process(message)
+            except Exception as e:
+                await client.get_channel(LOG_CHANNEL_ID).send(
+                    "<@354685615402385419>, <@178947222103130123> ! Une erreur inattendue est "
+                    f"survenue suite à ce message de {message.author.mention} : "
+                    f"{message.jump_url}\n"
+                    "Le contenu du message est le suivant :\n"
+                    f"> {message.content}\n"
+                    "L'erreur est la suivante :\n"
+                    "```\n"
+                    f"{traceback.format_exc()}\n"
+                    f"{e}\n"
+                    "```"
+                )
+                await message.channel.send(
+                    f"{message.author.mention} ! Une erreur inattendue est survenue. "
+                    "Les développeurs viennent d'en être informés. Merci de bien vouloir "
+                    "patienter."
+                )
+        else:
+            # Pour voir le traceback en local
             await module.process(message)
-        except Exception as e:
-            await client.get_channel(930777218496479302).send(
-                "<@354685615402385419>, <@178947222103130123> ! Une erreur inattendue est "
-                f"survenue suite à ce message de {message.author.mention} : "
-                f"{message.jump_url}\n"
-                "Le contenu du message est le suivant :\n"
-                f"> {message.content}\n"
-                "L'erreur est la suivante :\n"
-                "```\n"
-                f"{traceback.format_exc()}\n"
-                f"{e}\n"
-                "```"
-            )
-            await message.channel.send(
-                f"{message.author.mention} ! Une erreur inattendue est survenue. "
-                "Les développeurs viennent d'en être informés. Merci de bien vouloir "
-                "patienter."
-            )
 
 
 # Lancement du client

--- a/main.py
+++ b/main.py
@@ -64,11 +64,12 @@ async def on_ready():
 
     print("Bybbot opérationnel !")
 
-    #Si un channel est spécifié dans le fichier de conf
-    if LOG_CHANNEL_ID:
+    try:
         await client.get_channel(LOG_CHANNEL_ID).send(
             "Démarrage terminé, prêt à bybbotter des clous !"
         )
+    except:
+        pass
 
 
 @client.event
@@ -126,13 +127,13 @@ async def on_message(message):
         return
 
     for module in modules:
-
-        if LOG_CHANNEL_ID:
+        try:
+            await module.process(message)
+        except Exception as e:
             try:
-                await module.process(message)
-            except Exception as e:
                 await client.get_channel(LOG_CHANNEL_ID).send(
-                    "<@354685615402385419>, <@178947222103130123> ! Une erreur inattendue est "
+                    "<@354685615402385419>, <@178947222103130123> ! "
+                    "Une erreur inattendue est "
                     f"survenue suite à ce message de {message.author.mention} : "
                     f"{message.jump_url}\n"
                     "Le contenu du message est le suivant :\n"
@@ -148,9 +149,8 @@ async def on_message(message):
                     "Les développeurs viennent d'en être informés. Merci de bien vouloir "
                     "patienter."
                 )
-        else:
-            # Pour voir le traceback en local
-            await module.process(message)
+            except:
+                raise e
 
 
 # Lancement du client

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,7 @@ COMMAND_CHANNEL_ID = client_config.get("command_channel", 848302082150760508)
 SWAGCHAIN_CHANNEL_ID = client_config.get("swagchain_channel", 913946510616567848)
 
 # ID unique du canal de log, si il n'est pas défini, sa valeur sera False
-LOG_CHANNEL_ID = client_config.get("log_channel", False)
+LOG_CHANNEL_ID = client_config.get("log_channel", None)
 
 
 def format_number(n):

--- a/utils.py
+++ b/utils.py
@@ -21,6 +21,9 @@ COMMAND_CHANNEL_ID = client_config.get("command_channel", 848302082150760508)
 # ID unique du canal de la swag-chain
 SWAGCHAIN_CHANNEL_ID = client_config.get("swagchain_channel", 913946510616567848)
 
+# ID unique du canal de log, si il n'est pas défini, sa valeur sera False
+LOG_CHANNEL_ID = client_config.get("log_channel", False)
+
 
 def format_number(n):
     """Fonction qui permet de rajouter des espaces fin entre chaque


### PR DESCRIPTION
Add a configurable log_channel id in the config file.
If it's missing, all prompt usually in log_channel are send localy.